### PR TITLE
[feat,fix,bug] 기프티콘 거래 기능, 구매/방문 내역, 랭킹 집계, 기타사항

### DIFF
--- a/accounts/templates/accounts/mypage.html
+++ b/accounts/templates/accounts/mypage.html
@@ -26,6 +26,9 @@
         <input type="submit" value="프로필 수정" />
     </form>
 
+    <h3>내 리워드</h3>
+    <a href="{% url 'visit_rewards:my_rewards' %}">리워드 보기</a><br><br>
+
     <section class="setting">
         <h3>설정</h3>
         <div class="setting_detail">

--- a/accounts/templates/accounts/mypage.html
+++ b/accounts/templates/accounts/mypage.html
@@ -26,6 +26,9 @@
         <input type="submit" value="프로필 수정" />
     </form>
 
+    <h3>방문 내역</h3>
+    <a href="{% url 'visit_rewards:visit_history' %}">방문 내역</a><br><br>
+
     <h3>내 리워드</h3>
     <a href="{% url 'visit_rewards:my_rewards' %}">리워드 보기</a><br><br>
 

--- a/populate_gifticons.py
+++ b/populate_gifticons.py
@@ -1,0 +1,38 @@
+import os
+import django
+from django.core.files import File
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+
+from visit_rewards.models import Gifticon
+from django.conf import settings
+
+gifticons_data = [
+    ("기분좋은음식들", "기분좋은.png"),
+    ("반숙상회", "반숙상회.png"),
+    ("블랙다운", "블랙다운.png"),
+    ("양국", "양국.png"),
+    ("이요", "이요.png"),
+    ("조이키친", "조이키친.png"),
+    ("카페레", "카페레.png"),
+    ("커피공장", "커피공장.png"),
+]
+
+for name, filename in gifticons_data:
+    filepath = os.path.join(settings.MEDIA_ROOT, "gifticons", filename)
+    if not os.path.exists(filepath):
+        print(f"파일이 존재하지 않음: {filepath}")
+        continue
+
+    with open(filepath, "rb") as f:
+        gifticon_file = File(f, name=filename)
+        Gifticon.objects.create(
+            name=name,
+            point_cost=1000,
+            description=f"{name} 기프티콘",
+            image=gifticon_file
+        )
+    print(f"{name} 기프티콘 등록 완료")
+
+print("모든 기프티콘 등록 완료")

--- a/users/models.py
+++ b/users/models.py
@@ -14,6 +14,8 @@ class User(AbstractUser):
     email = models.EmailField(max_length=30, unique=True)
     nickname = models.CharField(max_length=30, unique=True)
     profile_image = models.ImageField(upload_to=upload_filepath, blank=True)
+    
+    points = models.PositiveIntegerField(default=0)
 
     groups = models.ManyToManyField(Group, related_name='users_custom', blank=True)
     user_permissions = models.ManyToManyField(Permission, related_name='users_custom', blank=True)

--- a/visit_rewards/templates/visit_rewards/gifticon_shop.html
+++ b/visit_rewards/templates/visit_rewards/gifticon_shop.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>기프티콘 샵</title>
+    <style>
+      ul {
+        list-style: none;
+        padding: 0;
+      }
+      li {
+        margin: 10px 0;
+      }
+      .gifticon-link {
+        text-decoration: none;
+        color: #333;
+        font-size: 16px;
+        padding: 8px 12px;
+        display: inline-block;
+        border: 1px solid #ddd;
+        border-radius: 6px;
+        transition: background 0.2s;
+      }
+      .gifticon-link:hover {
+        background: #f0f0f0;
+      }
+    </style>
+</head>
+<body>
+<h2>기프티콘 샵</h2>
+<p>내 포인트: {{ user_points }}점</p><br>
+<a href="{% url 'visit_rewards:my_gifticons' %}">내 기프티콘 보관함 보기</a><br><br>
+
+<ul>
+  {% for g in gifticons %}
+    <li>
+      {% if g.remaining_points >= 0 %}
+        <a href="{% url 'visit_rewards:buy_gifticon' g.id %}" 
+           class="gifticon-link"
+           onclick="return confirm('정말 {{ g.name }} 기프티콘을 구매하시겠습니까?\n가격: {{ g.point_cost }}P\n(구매 후 잔여 포인트: {{ g.remaining_points }}P)')">
+          {{ g.name }} - {{ g.point_cost }}P
+        </a>
+      {% else %}
+        <a href="javascript:void(0);" 
+           class="gifticon-link"
+           onclick="alert('잔여 포인트가 부족합니다.')">
+          {{ g.name }} - {{ g.point_cost }}P
+        </a>
+      {% endif %}
+    </li>
+{% endfor %}
+
+</ul>
+
+</body>
+</html>

--- a/visit_rewards/templates/visit_rewards/gifticon_shop.html
+++ b/visit_rewards/templates/visit_rewards/gifticon_shop.html
@@ -38,7 +38,7 @@
         <a href="{% url 'visit_rewards:buy_gifticon' g.id %}" 
            class="gifticon-link"
            onclick="return confirm('정말 {{ g.name }} 기프티콘을 구매하시겠습니까?\n가격: {{ g.point_cost }}P\n(구매 후 잔여 포인트: {{ g.remaining_points }}P)')">
-          {{ g.name }} - {{ g.point_cost }}P
+          {{ g.name }} {{ g.description }}- {{ g.point_cost }}P
         </a>
       {% else %}
         <a href="javascript:void(0);" 

--- a/visit_rewards/templates/visit_rewards/item_shop.html
+++ b/visit_rewards/templates/visit_rewards/item_shop.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>QR 방문 인증</title>
+    <script src="https://unpkg.com/html5-qrcode" type="text/javascript"></script>
+</head>
+<body>
+    <a href="{% url 'visit_rewards:my_rewards' %}">내 리워드 보기</a><br><br>
+    <h2>아이템 샵</h2>
+    <p>보유 포인트: {{ user_points }}점</p>
+
+    <ul>
+        {% for item in items %}
+            <li>
+                {{ item.name }} ({{ item.point_cost }}점)
+                <a href="{% url 'visit_rewards:buy_item' item.id %}">구매</a>
+            </li>
+        {% endfor %}
+    </ul>
+
+
+</body>
+</html>
+    

--- a/visit_rewards/templates/visit_rewards/my_gifticons.html
+++ b/visit_rewards/templates/visit_rewards/my_gifticons.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>내 기프티콘</title>
+    <style>
+      .gifticon-img {
+          cursor: pointer;
+          transition: transform 0.3s ease;
+      }
+      .gifticon-img.enlarged {
+          transform: scale(2); /* 2배 확대 */
+          z-index: 1000;
+          position: relative;
+      }
+    </style>
+</head>
+<body>
+  <a href="{% url 'accounts:mypage' %}">마이페이지</a><br><br>
+  <h3>내 기프티콘</h3>
+  <ul id="gifticon-list">
+      {% for reward in gifticons %}
+          <li id="gift-{{ reward.id }}">
+              {% if reward.gifticon.image %}
+                  <img src="{{ reward.gifticon.image.url }}" 
+                       alt="{{ reward.gifticon.name }}" 
+                       class="gifticon-img"
+                       width="100">
+              {% endif %}
+              사용처 [{{ reward.gifticon.name }}] 유효기간 [~2025.12.31]
+  
+              {% if reward.used %}
+                  (사용 완료)
+              {% else %}
+                  <input type="checkbox" 
+                         class="use-gifticon" 
+                         data-id="{{ reward.id }}">
+                  <label>사용 완료</label>
+              {% endif %}
+          </li>
+      {% empty %}
+          <li>보유한 기프티콘이 없습니다.</li>
+      {% endfor %}
+  </ul>
+  
+  <a href="{% url 'visit_rewards:shop_gifticons' %}">기프티콘 샵으로 돌아가기</a>
+  
+  <script>
+  // 이미지 클릭 시 확대/축소
+  document.addEventListener("DOMContentLoaded", function() {
+      document.querySelectorAll(".gifticon-img").forEach(img => {
+          img.addEventListener("click", function() {
+              this.classList.toggle("enlarged");
+          });
+      });
+  });
+  </script>
+
+  <script>
+  // 체크박스로 기프티콘 사용 처리
+  document.addEventListener("DOMContentLoaded", function() {
+      document.querySelectorAll(".use-gifticon").forEach(function(checkbox) {
+          checkbox.addEventListener("change", function() {
+              const gifticonId = this.dataset.id;
+  
+              if (this.checked) {
+                  if (confirm("정말로 이 기프티콘을 사용하시겠습니까?")) {
+                      fetch("{% url 'visit_rewards:use_gifticon' %}", {
+                          method: "POST",
+                          headers: {
+                              "Content-Type": "application/json",
+                              "X-CSRFToken": "{{ csrf_token }}"
+                          },
+                          body: JSON.stringify({ id: gifticonId })
+                      })
+                      .then(res => {
+                          if (res.ok) {
+                              // 성공 시 화면에서 제거
+                              document.getElementById("gift-" + gifticonId).remove();
+                          } else {
+                              alert("사용 처리에 실패했습니다.");
+                              this.checked = false;
+                          }
+                      });
+                  } else {
+                      this.checked = false; // 취소 시 원상 복구
+                  }
+              }
+          });
+      });
+  });
+  </script>
+</body>
+</html>

--- a/visit_rewards/templates/visit_rewards/my_rewards.html
+++ b/visit_rewards/templates/visit_rewards/my_rewards.html
@@ -8,6 +8,7 @@
 <body>
     <a href="{% url 'accounts:main' %}">홈으로</a><br><br>
     <h2>내 포인트: {{ points }}점</h2>
+   
     <a href="{% url 'visit_rewards:purchase_history' %}">구매 내역</a><br><br>
 
     <h3>내 아이템</h3>

--- a/visit_rewards/templates/visit_rewards/my_rewards.html
+++ b/visit_rewards/templates/visit_rewards/my_rewards.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>QR 방문 인증</title>
+    <script src="https://unpkg.com/html5-qrcode" type="text/javascript"></script>
+</head>
+<body>
+    <a href="{% url 'accounts:main' %}">홈으로</a><br><br>
+    <h2>내 포인트: {{ points }}점</h2>
+
+    <h3>내 아이템</h3>
+    <ul>
+    {% for user_item in items %}
+        <li>{{ user_item.item.name }}</li>
+    {% empty %}
+        <li>보유한 아이템이 없습니다.</li>
+    {% endfor %}
+    </ul>
+
+    <a href="{% url 'visit_rewards:my_gifticons' %}">내 기프티콘</a><br><br>
+
+
+    <a href="{% url 'visit_rewards:shop_items' %}">아이템 샵</a>
+    <a href="{% url 'visit_rewards:shop_gifticons' %}">기프티콘 샵</a>
+
+</body>
+</html>
+    

--- a/visit_rewards/templates/visit_rewards/my_rewards.html
+++ b/visit_rewards/templates/visit_rewards/my_rewards.html
@@ -8,6 +8,7 @@
 <body>
     <a href="{% url 'accounts:main' %}">홈으로</a><br><br>
     <h2>내 포인트: {{ points }}점</h2>
+    <a href="{% url 'visit_rewards:purchase_history' %}">구매 내역</a><br><br>
 
     <h3>내 아이템</h3>
     <ul>

--- a/visit_rewards/templates/visit_rewards/purchase_history.html
+++ b/visit_rewards/templates/visit_rewards/purchase_history.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>구매 내역</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+        h2 {
+            margin-bottom: 20px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 30px;
+        }
+        th, td {
+            padding: 12px;
+            border: 1px solid #ddd;
+            text-align: left;
+        }
+        th {
+            background-color: #f8f8f8;
+        }
+        tr:nth-child(even) {
+            background-color: #f5f5f5;
+        }
+        .back-link {
+            display: inline-block;
+            padding: 8px 12px;
+            background-color: #eee;
+            border-radius: 6px;
+            text-decoration: none;
+            color: #333;
+            transition: background 0.2s;
+        }
+        .back-link:hover {
+            background-color: #ddd;
+        }
+    </style>
+</head>
+<body>
+    <h2>내 기프티콘 구매 내역</h2>
+
+    {% if purchase_history %}
+    <table>
+        <thead>
+            <tr>
+                <th>기프티콘 이름</th>
+                <th>사용 여부</th>
+                <th>포인트 사용량</th>
+                <th>구매 날짜</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for ph in purchase_history %}
+            <tr>
+                <td>{{ ph.gifticon.name }}</td>
+                <td>
+                    {% if ph.used %}
+                        사용 완료
+                    {% else %}
+                        미사용
+                    {% endif %}
+                </td>
+                <td>{{ ph.points_spent }}P</td>
+                <td>{{ ph.purchased_at|date:"Y-m-d H:i" }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+        <p>구매한 기프티콘이 없습니다.</p>
+    {% endif %}
+
+    <a href="{% url 'visit_rewards:shop_gifticons' %}" class="back-link">기프티콘 샵으로 돌아가기</a>
+</body>
+</html>

--- a/visit_rewards/templates/visit_rewards/visit_checking.html
+++ b/visit_rewards/templates/visit_rewards/visit_checking.html
@@ -53,8 +53,10 @@
                 })
                 .then(data => {
                     if (data.status === "ok") {
-                        statusEl.textContent =
-                            `[${data.store_name}] 방문을 환영합니다! (누적 방문 ${data.total_visits}회)`;
+                        statusEl.innerHTML =
+                            `[${data.store_name}] 방문을 환영합니다! (누적 방문 ${data.total_visits}회)<br>` +
+                            `${data.points_earned}포인트가 적립되었습니다! ` +
+                            `<a href="http://127.0.0.1:8000/visit_rewards/rewards/">내 리워드 보기</a>`;
                     } else if (data.status === "already_visited") {
                         statusEl.textContent = "이미 방문한 QR입니다. 내일 다시 시도해주세요.";
                     } else {

--- a/visit_rewards/templates/visit_rewards/visit_history.html
+++ b/visit_rewards/templates/visit_rewards/visit_history.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>나의 방문 내역</title>
+    <style>
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; }
+        tr:hover { background-color: #f9f9f9; }
+        .store-link { color: #007bff; text-decoration: none; font-weight: bold; }
+        .store-link:hover { text-decoration: underline; }
+        .highlight { background-color: #fffae6; padding: 5px; margin-bottom: 10px; display: inline-block; }
+    </style>
+</head>
+<body>
+<h2>나의 방문 내역</h2>
+<a href="{% url 'home:main' %}">홈으로</a>
+<br><br>
+
+{% if most_visited %}
+<div class="highlight">
+    <strong>가장 많이 찾은 가게:</strong>
+    <a href="{% url 'stores:store-detail' most_visited.store__id %}" class="store-link">
+        {{ most_visited.store__name }}
+    </a>
+    (방문 횟수: {{ most_visited.visits_count }}회)
+</div>
+{% endif %}
+
+{% if latest_visit %}
+<div class="highlight">
+    <strong>가장 최근에 찾은 가게:</strong>
+    <a href="{% url 'stores:store-detail' latest_visit.store.id %}" class="store-link">
+        {{ latest_visit.store.name }}
+    </a>
+    (방문 시간: {{ latest_visit.visit_time|date:"Y-m-d H:i" }})
+</div>
+{% endif %}
+
+{% if visits %}
+<table>
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>가게 이름</th>
+            <th>테스트 여부</th>
+            <th>방문 시간</th>
+            <th>획득 포인트</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for visit in visits %}
+        <tr>
+            <td>{{ forloop.counter }}</td>
+            <td>
+                <a href="{% url 'stores:store-detail' visit.store.id %}" class="store-link">
+                    {{ visit.store.name }}
+                </a>
+            </td>
+            <td>{% if visit.test %}테스트{% else %}실제{% endif %}</td>
+            <td>{{ visit.visit_time|date:"Y-m-d H:i" }}</td>
+            <td>
+                {% with visit.reward_set.first as r %}
+                    {% if r %}{{ r.amount }}P{% else %}-{% endif %}
+                {% endwith %}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>아직 방문한 가게가 없습니다.</p>
+{% endif %}
+</body>
+</html>

--- a/visit_rewards/urls.py
+++ b/visit_rewards/urls.py
@@ -20,4 +20,7 @@ urlpatterns = [
     path('shop/gifticons/buy/<int:gifticon_id>/', views.buy_gifticon, name='buy_gifticon'),  # 기프티콘 구매
     path('gifticons/my/', views.my_gifticons, name='my_gifticons'),              # 보유 기프티콘 확인
     path('gifticons/use/', views.use_gifticon, name='use_gifticon'),
+    
+    # 구매 내역
+    path('gifticons/purchase-history/', views.purchase_history, name='purchase_history'),
 ]

--- a/visit_rewards/urls.py
+++ b/visit_rewards/urls.py
@@ -4,7 +4,20 @@ from . import views
 app_name = "visit_rewards"
 
 urlpatterns = [
-  
-    path('visit_check/<int:store_id>/', views.visit_check, name='visit_check'),# QR 인증 화면
-    path('visit/', views.visit_store, name='visit_store'),  # QR 스캔 후 API
+    # 방문 관련
+    path('visit_check/<int:store_id>/', views.visit_check, name='visit_check'),  # QR 인증 화면
+    path('visit/', views.visit_store, name='visit_store'),                        # QR 스캔 후 API
+
+    # 내 보유 포인트/아이템/기프티콘
+    path('rewards/', views.my_rewards, name='my_rewards'),
+
+    # 꾸미기 아이템 관련
+    path('shop/items/', views.shop_items, name='shop_items'),                     # 아이템 샵
+    path('shop/items/buy/<int:item_id>/', views.buy_item, name='buy_item'),      # 아이템 구매
+
+    # 기프티콘 관련
+    path('shop/gifticons/', views.shop_gifticons, name='shop_gifticons'),        # 기프티콘 샵
+    path('shop/gifticons/buy/<int:gifticon_id>/', views.buy_gifticon, name='buy_gifticon'),  # 기프티콘 구매
+    path('gifticons/my/', views.my_gifticons, name='my_gifticons'),              # 보유 기프티콘 확인
+    path('gifticons/use/', views.use_gifticon, name='use_gifticon'),
 ]

--- a/visit_rewards/urls.py
+++ b/visit_rewards/urls.py
@@ -23,4 +23,6 @@ urlpatterns = [
     
     # 구매 내역
     path('gifticons/purchase-history/', views.purchase_history, name='purchase_history'),
+    # 방문 내역
+    path('visit_history/', views.visit_history, name='visit_history'),
 ]

--- a/visit_rewards/views.py
+++ b/visit_rewards/views.py
@@ -52,25 +52,23 @@ def visit_store(request):
 
     store = get_object_or_404(Store, qr_token=token)
 
-    if not is_test and Visit.objects.filter(store=store, user=request.user).exists():
-        return JsonResponse({"status": "already_visited"})
-
-        # 방문 인증 생성
+    # 방문 인증 생성
     visit = Visit.objects.create(store=store, test=is_test, user=request.user)
 
     # 포인트 적립 (예: 방문 인증 1000포인트)
     points_earned = 1000
     Reward.objects.create(
-    user=request.user,
-    reward_type='visit',
-    amount=points_earned,
-    related_visit=visit
-)
-    
+        user=request.user,
+        reward_type='visit',
+        amount=points_earned,
+        related_visit=visit
+    )
+
     request.user.points += points_earned
     request.user.save()
 
-    total_visits = Visit.objects.filter(store=store).count()
+    # 로그인 사용자 기준 누적 방문 횟수
+    total_visits = Visit.objects.filter(store=store, user=request.user).count()
 
     return JsonResponse({
         "status": "ok",

--- a/visit_rewards/views.py
+++ b/visit_rewards/views.py
@@ -1,9 +1,14 @@
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, render,redirect
 from django.http import JsonResponse, HttpResponse
 from .models import Store, Visit
 import uuid, base64, qrcode
 from io import BytesIO
 from django.contrib.auth.decorators import login_required
+from django.contrib import messages
+from .models import *
+from django.db.models import Sum
+from django.views.decorators.http import require_POST
+import json
 
 # 방문 인증 페이지 + QR 생성
 def visit_check(request, store_id):
@@ -50,12 +55,196 @@ def visit_store(request):
     if not is_test and Visit.objects.filter(store=store, user=request.user).exists():
         return JsonResponse({"status": "already_visited"})
 
-    Visit.objects.create(store=store, test=is_test, user=request.user)
+        # 방문 인증 생성
+    visit = Visit.objects.create(store=store, test=is_test, user=request.user)
+
+    # 포인트 적립 (예: 방문 인증 1000포인트)
+    points_earned = 1000
+    Reward.objects.create(
+    user=request.user,
+    reward_type='visit',
+    amount=points_earned,
+    related_visit=visit
+)
+    
+    request.user.points += points_earned
+    request.user.save()
 
     total_visits = Visit.objects.filter(store=store).count()
 
     return JsonResponse({
         "status": "ok",
         "store_name": store.name,
-        "total_visits": total_visits
+        "total_visits": total_visits,
+        "points_earned": points_earned
     })
+
+
+#이 위로 방문인증 관련
+#-----------------------------------------------------------------------
+#이 밑으로 리워드 관련
+
+@login_required
+def my_rewards(request):
+    """유저가 가진 포인트와 아이템 확인"""
+    total_points = Reward.objects.filter(
+        user=request.user,
+        used=False,
+        amount__gt=0
+    ).aggregate(total=Sum('amount'))['total'] or 0
+
+    # 사용되지 않은 꾸미기 아이템
+    items_qs = Reward.objects.filter(
+        user=request.user,
+        item__isnull=False,
+        used=False
+    ).select_related('item')
+    items = list({r.item for r in items_qs})
+
+    # 보유 기프티콘
+    gifticons_qs = Reward.objects.filter(
+        user=request.user,
+        gifticon__isnull=False,
+        used=False
+    ).select_related('gifticon')
+    gifticons = list({r.gifticon for r in gifticons_qs})
+
+    return render(request, 'visit_rewards/my_rewards.html', {
+        'points': total_points,
+        'items': items,
+        'gifticons': gifticons,
+    })
+
+
+@login_required
+def shop_items(request):
+    """구매 가능한 꾸미기 아이템 목록"""
+    items = Item.objects.all()
+    user_points = Reward.objects.filter(user=request.user, amount__gt=0, used=False).aggregate(total=Sum('amount'))['total'] or 0
+    return render(request, 'visit_rewards/item_shop.html', {'items': items, 'user_points': user_points})
+
+
+@login_required
+def buy_item(request, item_id):
+    """포인트로 꾸미기 아이템 구매"""
+    item = get_object_or_404(Item, pk=item_id)
+    user_points = Reward.objects.filter(user=request.user, amount__gt=0, used=False).aggregate(total=Sum('amount'))['total'] or 0
+
+    if user_points < item.point_cost:
+        messages.error(request, f"포인트가 부족합니다. 현재 {user_points}점, 아이템 비용 {item.point_cost}점")
+        return redirect('visit_rewards:shop_items')
+
+    # 포인트 차감
+    remaining_cost = item.point_cost
+    rewards = Reward.objects.filter(user=request.user, amount__gt=0, used=False).order_by('created_at')
+    for r in rewards:
+        if r.amount >= remaining_cost:
+            r.amount -= remaining_cost
+            if r.amount == 0:
+                r.used = True
+            r.save()
+            break
+        else:
+            remaining_cost -= r.amount
+            r.amount = 0
+            r.used = True
+            r.save()
+
+    # 구매 기록 생성
+    PurchaseHistory.objects.create(user=request.user, item=item, points_spent=item.point_cost)
+
+    # 아이템 지급
+    Reward.objects.create(user=request.user, item=item, amount=0)
+
+    messages.success(request, f"{item.name} 아이템을 구매했습니다!")
+    return redirect('visit_rewards:my_rewards')
+
+
+@login_required
+def shop_gifticons(request):
+    """구매 가능한 기프티콘 목록"""
+    # 모든 기프티콘 가져오기
+    gifticons = Gifticon.objects.all()
+
+    # 유저 현재 포인트 계산
+    user_points = Reward.objects.filter(
+        user=request.user,
+        amount__gt=0,
+        used=False
+    ).aggregate(total=Sum('amount'))['total'] or 0
+
+    # 각 기프티콘별 구매 후 잔여 포인트 계산
+    for g in gifticons:
+        g.remaining_points = user_points - g.point_cost
+
+    return render(request, 'visit_rewards/gifticon_shop.html', {
+        'gifticons': gifticons,
+        'user_points': user_points,
+    })
+
+@login_required
+def buy_gifticon(request, gifticon_id):
+    """포인트로 기프티콘 구매"""
+    gifticon = get_object_or_404(Gifticon, pk=gifticon_id)
+    user_points = Reward.objects.filter(user=request.user, amount__gt=0, used=False).aggregate(total=Sum('amount'))['total'] or 0
+
+    if user_points < gifticon.point_cost:
+        messages.error(request, f"포인트가 부족합니다. 현재 {user_points}점, 기프티콘 비용 {gifticon.point_cost}점")
+        return redirect('visit_rewards:shop_gifticons')
+
+    # 포인트 차감
+    remaining_cost = gifticon.point_cost
+    rewards = Reward.objects.filter(user=request.user, amount__gt=0, used=False).order_by('created_at')
+    for r in rewards:
+        if r.amount >= remaining_cost:
+            r.amount -= remaining_cost
+            if r.amount == 0:
+                r.used = True
+            r.save()
+            break
+        else:
+            remaining_cost -= r.amount
+            r.amount = 0
+            r.used = True
+            r.save()
+
+    # 구매 기록 생성
+    PurchaseHistory.objects.create(user=request.user, gifticon=gifticon, points_spent=gifticon.point_cost)
+
+    # 기프티콘 지급
+    Reward.objects.create(user=request.user, gifticon=gifticon, amount=0)
+
+    messages.success(request, f"{gifticon.name} 기프티콘을 구매했습니다!")
+    return redirect('visit_rewards:my_rewards')
+
+
+@login_required
+def my_gifticons(request):
+    """유저가 보유한 기프티콘 확인"""
+    gifticons = Reward.objects.filter(
+        user=request.user,
+        gifticon__isnull=False,
+        used=False
+    ).select_related('gifticon')
+
+    return render(request, 'visit_rewards/my_gifticons.html', {'gifticons': gifticons})
+
+@login_required
+@require_POST
+def use_gifticon(request):
+    """체크박스로 기프티콘 사용 처리"""
+    try:
+        data = json.loads(request.body)
+        reward_id = data.get("id")
+    except (json.JSONDecodeError, KeyError):
+        return JsonResponse({"success": False, "error": "잘못된 요청"}, status=400)
+
+    reward = get_object_or_404(Reward, id=reward_id, user=request.user, gifticon__isnull=False)
+
+    if reward.used:
+        return JsonResponse({"success": False, "error": "이미 사용된 기프티콘"}, status=400)
+
+    reward.used = True
+    reward.save()
+
+    return JsonResponse({"success": True})

--- a/visit_rewards/views.py
+++ b/visit_rewards/views.py
@@ -248,3 +248,18 @@ def use_gifticon(request):
     reward.save()
 
     return JsonResponse({"success": True})
+
+@login_required
+def purchase_history(request):
+    """
+    현재 유저의 기프티콘 구매 내역
+    """
+    history = PurchaseHistory.objects.filter(user=request.user).select_related('gifticon').order_by('-purchased_at')
+    
+    # 각 구매 내역마다 사용 여부 표시
+    for ph in history:
+        ph.used = Reward.objects.filter(user=request.user, gifticon=ph.gifticon, used=True).exists()
+    
+    return render(request, 'visit_rewards/purchase_history.html', {
+        'purchase_history': history
+    })


### PR DESCRIPTION
## 📌 개요
- 포인트 적립 기반 기프티콘 거래 기능 추가
- QR 방문인증 기반 가게 인기랭킹 집계
- 포인트 적립 내역/구매 내역/방문 내역 확인

## ✨ 작업 내용
- 방문 인증 기반 가게 인기랭킹 집계(계정당 최대 1일 2회)
- 방문 인증 시 자동 포인트 적립(임시로 1000p)
- 방문 내역 확인: 최근방문/최다방문 필터링
- 내 리워드>내 아이템/내 기프티콘/아이템샵/기프티콘샵/구매내역 페이지 추가
- 잔여 포인트로 기프티콘 구매 가능
- 기프티콘 구매 시 내 기프티콘 보관함에 기프티콘 이미지 자동 보관
- 기프티콘 사용 처리 시 보관함에서 기프티콘 삭제
- 구매 내역 확인 
- 로그인된 사용자의 가게당 누적방문수 집계 에러 수정

## ✅ 확인 방법
- 방문인증 시 포인트 적립 안내, 1000포인트가 잘 적립되는지 확인
- 방문한 가게의 방문 수가 올라가는지 확인
- 한 가게에 여러 번 방문해도 하루에 방문수가 2 이상은 올라가지 않는지 확인
- 마이페이지>내 리워드>아이템/기프티콘 페이지 잘 연결되는지 확인
- 잔여 포인트로 기프티콘이 성공적으로 구매되고 포인트가 금액에 맞게 차감되는지 확인
- 구매한 기프티콘을 기프티콘 보관함에서 이미지로 확인, 클릭 시 확대 되는지 확인
- 기프티콘 사용 처리 시 보관함에서 해당 기프티콘이 사라지는지 확인
- 구매 내역 페이지에서 구매한 이력과 기프티콘 사용 여부가 잘 보이는지 확인
- 방문 내역 페이지에서 방문인증된 가게 이력이 보이는지 확인
- 방문 내역 페이지에서 최다 방문, 최근 방문한 가게가 상단에 보이는지 확인

## 🔗 관련 이슈
- closes #18
- closes #20 
- closes #21 
- 가게 DB 있어야 방문인증 테스트 가능
>임시로 방문인증 페이지에서 해당 가게의 QR 이미지를 띄워두었으니 핸드폰으로 캡쳐 후 컴퓨터 카메라에 스캔해보세요
- 단톡에 올린 기프티콘 이미지, db 설정 방법 참고