### PR TITLE
[feat] 사용자 선호 지역/음식 설정, 관심 가게 설정 기능 추가

### DIFF
--- a/accounts/templates/accounts/favorite_stores.html
+++ b/accounts/templates/accounts/favorite_stores.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>찜한 가게</title>
+    <style>
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { border: 1px solid #ccc; padding: 10px; text-align: left; }
+        th { background-color: #f0f0f0; }
+        a.store-link { color: blue; text-decoration: underline; }
+        button { padding: 5px 10px; cursor: pointer; }
+    </style>
+</head>
+<body>
+<h2>찜한 가게</h2>
+<a href="{% url 'home:main' %}">홈으로</a>
+<br><br>
+
+{% if favorites %}
+<table>
+    <thead>
+        <tr>
+            <th>가게 이름</th>
+            <th>찜 날짜</th>
+            <th>액션</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for fav in favorites %}
+        <tr id="fav-{{ fav.id }}">
+            <td>
+                <a href="{% url 'stores:store-detail' fav.store.id %}" class="store-link">
+                    {{ fav.store.name }}
+                </a>
+            </td>
+            <td>{{ fav.created_at|date:"Y-m-d H:i" }}</td>
+            <td>
+                <button class="toggle-fav" data-store="{{ fav.store.id }}">찜 해제</button>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>찜한 가게가 없습니다.</p>
+{% endif %}
+
+<script>
+document.querySelectorAll('.toggle-fav').forEach(btn => {
+    btn.addEventListener('click', () => {
+        const storeId = btn.dataset.store;
+        if(confirm("찜을 해제하시겠습니까?")) {
+            fetch("{% url 'accounts:toggle_favorite' %}", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "X-CSRFToken": "{{ csrf_token }}"
+                },
+                body: `store_id=${storeId}`
+            })
+            .then(res => res.json())
+            .then(data => {
+                if(data.status === "removed") {
+                    const row = document.getElementById(`fav-${storeId}`);
+                    if(row) row.remove();
+                } else {
+                    alert("찜 해제 실패");
+                }
+            });
+        }
+    });
+});
+</script>
+</body>
+</html>

--- a/accounts/templates/accounts/mypage.html
+++ b/accounts/templates/accounts/mypage.html
@@ -26,6 +26,9 @@
         <input type="submit" value="프로필 수정" />
     </form>
 
+    <h3>내 리워드</h3>
+    <a href="{% url 'visit_rewards:my_rewards' %}">리워드 보기</a><br><br>
+
     <section class="setting">
         <h3>설정</h3>
         <div class="setting_detail">

--- a/accounts/templates/accounts/mypage.html
+++ b/accounts/templates/accounts/mypage.html
@@ -26,6 +26,9 @@
         <input type="submit" value="프로필 수정" />
     </form>
 
+    <h3>방문 내역</h3>
+    <a href="{% url 'visit_rewards:visit_history' %}">방문 내역</a><br><br>
+
     <h3>내 리워드</h3>
     <a href="{% url 'visit_rewards:my_rewards' %}">리워드 보기</a><br><br>
 

--- a/accounts/templates/accounts/mypage.html
+++ b/accounts/templates/accounts/mypage.html
@@ -26,6 +26,19 @@
         <input type="submit" value="프로필 수정" />
     </form>
 
+    <h3>관심 설정</h3>
+
+    <p>선호 음식: {{ preference.preferred_food|default:"설정되지 않음" }}</p>
+    <p>선호 위치: {{ preference.preferred_location|default:"설정되지 않음" }}</p>
+
+
+    <a href="{% url 'accounts:user_preferences' %}">
+        <button type="button">수정</button>
+    </a>
+
+    <h3>찜한 가게</h3>
+    <a href="{% url 'accounts:favorite_stores' %}">찜 목록</a><br><br>
+
     <h3>방문 내역</h3>
     <a href="{% url 'visit_rewards:visit_history' %}">방문 내역</a><br><br>
 

--- a/accounts/templates/accounts/user_preferences.html
+++ b/accounts/templates/accounts/user_preferences.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>관심 설정</title>
+</head>
+<body>
+<h2>관심 설정</h2>
+<a href="{% url 'home:main' %}">홈으로</a>
+<br><br>
+
+<form method="post" action="{% url 'accounts:user_preferences' %}">
+    {% csrf_token %}
+
+    <!-- 선호 음식 선택 -->
+    <label for="preferred_food">선호 음식:</label>
+    <select name="preferred_food" id="preferred_food">
+        <option value="">선택</option>
+        <option value="한식" {% if preference.preferred_food == "한식" %}selected{% endif %}>한식</option>
+        <option value="양식" {% if preference.preferred_food == "양식" %}selected{% endif %}>양식</option>
+        <option value="중식" {% if preference.preferred_food == "중식" %}selected{% endif %}>중식</option>
+        <option value="일식" {% if preference.preferred_food == "일식" %}selected{% endif %}>일식</option>
+        <option value="기타" {% if preference.preferred_food == "기타" %}selected{% endif %}>기타</option>
+    </select>
+    <br><br>
+
+    <!-- 위치 입력 -->
+    <label for="preferred_location">선호 위치:</label>
+    <input type="text" name="preferred_location" id="preferred_location"
+        value="{{ preference.preferred_location }}" placeholder="예: 강남구">
+    <br><br>
+
+    <button type="submit">저장</button>
+</form>

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 from .views import *
+from . import views
 
 app_name="accounts"
 
@@ -17,12 +18,17 @@ path('api/user/', user_info_view, name='user_info'),
 
 path('visit_check/',visit_check,name='visit_check'),
 
-# FE 템플릿 렌더링
+
 path('page/mypage/', my_page_view, name='mypage'),
 path('page/login/', login_page_view, name='login_page'),
 path('page/signup/', signup_page_view, name='signup_page'),
 
 path('terms/', lambda request: terms_or_policy_view(request, 'terms'), name='terms_of_service'),
 path('privacy/', lambda request: terms_or_policy_view(request, 'privacy'), name='privacy_policy'),
+
+
+path('preferences/', views.user_preferences, name='user_preferences'),
+path('favorites/', views.favorite_stores, name='favorite_stores'),
+path('favorites/toggle/', views.toggle_favorite, name='toggle_favorite'),
 
 ]

--- a/populate_gifticons.py
+++ b/populate_gifticons.py
@@ -1,0 +1,38 @@
+import os
+import django
+from django.core.files import File
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+
+from visit_rewards.models import Gifticon
+from django.conf import settings
+
+gifticons_data = [
+    ("기분좋은음식들", "기분좋은.png"),
+    ("반숙상회", "반숙상회.png"),
+    ("블랙다운", "블랙다운.png"),
+    ("양국", "양국.png"),
+    ("이요", "이요.png"),
+    ("조이키친", "조이키친.png"),
+    ("카페레", "카페레.png"),
+    ("커피공장", "커피공장.png"),
+]
+
+for name, filename in gifticons_data:
+    filepath = os.path.join(settings.MEDIA_ROOT, "gifticons", filename)
+    if not os.path.exists(filepath):
+        print(f"파일이 존재하지 않음: {filepath}")
+        continue
+
+    with open(filepath, "rb") as f:
+        gifticon_file = File(f, name=filename)
+        Gifticon.objects.create(
+            name=name,
+            point_cost=1000,
+            description=f"{name} 기프티콘",
+            image=gifticon_file
+        )
+    print(f"{name} 기프티콘 등록 완료")
+
+print("모든 기프티콘 등록 완료")

--- a/stores/templates/stores/store-detail.html
+++ b/stores/templates/stores/store-detail.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <a href='{% url 'stores:public-store-list' %}'>가게 목록</a>
-    <br/>
+    <br/><br>
 
     {% if store.image %}
         <a href="{{ store.image.url }}" target="_blank">
@@ -21,34 +21,38 @@
 
     <h2>{{ store.name }}</h2>
 
+    <!-- 찜 버튼 -->
+    <button id="favorite-btn" data-store="{{ store.id }}">
+        {% if is_favorite %}
+            ♥ 찜 해제
+        {% else %}
+            ♡ 찜하기
+        {% endif %}
+    </button>
+    <br/><br/>
+
     주소: {{ store.address }} 
     <br/>
 
     <a href="{% url 'reviews:review-list' store.id %}">
-        <!-- 점수 -->
         ★{{ store.rating|floatformat:1 }} 
-        <!-- 리뷰 개수 -->
         ({{ store.reviews.count }})
     </a>
     <br/>
 
     카테고리:
-        {% for category in store.category.all %}
-            {{ category.name }}{% if not forloop.last %}, {% endif %}
-        {% endfor %}
+    {% for category in store.category.all %}
+        {{ category.name }}{% if not forloop.last %}, {% endif %}
+    {% endfor %}
     <br/><br>
 
     <a href="{% url 'visit_rewards:visit_check' store.id %}">방문 인증</a>
+    <br/><br>
 
-    <!-- 영업 -->
-            {% if store.open_time and store.close_time %}
-                영업 시간: {{ store.open_time|time:"H:i" }} ~ {{ store.close_time|time:"H:i" }}
-                {% if store.is_open %}
-                    (영업 중)
-                {% else %}
-                    (영업 종료)
-                {% endif %}
-            {% endif %}
+    {% if store.open_time and store.close_time %}
+        영업 시간: {{ store.open_time|time:"H:i" }} ~ {{ store.close_time|time:"H:i" }}
+        {% if store.is_open %}(영업 중){% else %}(영업 종료){% endif %}
+    {% endif %}
     <hr/>
 
     <h3>진행 중인 미션</h3>
@@ -61,15 +65,34 @@
             <br/>
             {{ mission.start_date }} ~ {{ mission.end_date }}
             <br/>
-
-            <!--미션 완료 링크(확인용 - 임의로 만들어 둠)-->
             <a href='{% url 'missions:mission-complete' mission.id %}'>미션 완료</a>
         </div>
     {% empty %}
         진행 중인 미션이 없습니다.
     {% endfor %}
 
-    <!-- 메뉴 및 서비스 추가 예정 -->
+<script>
+document.getElementById('favorite-btn').addEventListener('click', function() {
+    const storeId = this.dataset.store;
+    fetch("{% url 'accounts:toggle_favorite' %}", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "X-CSRFToken": "{{ csrf_token }}"
+        },
+        body: `store_id=${storeId}`
+    })
+    .then(res => res.json())
+    .then(data => {
+        if(data.status === "added") {
+            this.textContent = "♥ 찜 해제";
+        } else if(data.status === "removed") {
+            this.textContent = "♡ 찜하기";
+        } else {
+            alert("찜 처리에 실패했습니다.");
+        }
+    });
+});
+</script>
 </body>
 </html>
-

--- a/users/models.py
+++ b/users/models.py
@@ -14,6 +14,8 @@ class User(AbstractUser):
     email = models.EmailField(max_length=30, unique=True)
     nickname = models.CharField(max_length=30, unique=True)
     profile_image = models.ImageField(upload_to=upload_filepath, blank=True)
+    
+    points = models.PositiveIntegerField(default=0)
 
     groups = models.ManyToManyField(Group, related_name='users_custom', blank=True)
     user_permissions = models.ManyToManyField(Permission, related_name='users_custom', blank=True)

--- a/users/models.py
+++ b/users/models.py
@@ -3,6 +3,8 @@ from django.contrib.auth.models import AbstractUser, Group, Permission
 import os
 from uuid import uuid4
 from django.utils import timezone
+from django.conf import settings
+
 
 
 def upload_filepath(instance, filename):
@@ -22,3 +24,19 @@ class User(AbstractUser):
 
     def __str__(self):
         return self.username
+
+
+from stores.models import Store
+
+class UserPreference(models.Model):
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='preference')
+    preferred_food = models.CharField(max_length=50, blank=True, null=True)
+    preferred_location = models.CharField(max_length=100, blank=True, null=True)
+
+class FavoriteStore(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='favorites')
+    store = models.ForeignKey(Store, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ('user', 'store')

--- a/visit_rewards/templates/visit_rewards/gifticon_shop.html
+++ b/visit_rewards/templates/visit_rewards/gifticon_shop.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>기프티콘 샵</title>
+    <style>
+      ul {
+        list-style: none;
+        padding: 0;
+      }
+      li {
+        margin: 10px 0;
+      }
+      .gifticon-link {
+        text-decoration: none;
+        color: #333;
+        font-size: 16px;
+        padding: 8px 12px;
+        display: inline-block;
+        border: 1px solid #ddd;
+        border-radius: 6px;
+        transition: background 0.2s;
+      }
+      .gifticon-link:hover {
+        background: #f0f0f0;
+      }
+    </style>
+</head>
+<body>
+<h2>기프티콘 샵</h2>
+<p>내 포인트: {{ user_points }}점</p><br>
+<a href="{% url 'visit_rewards:my_gifticons' %}">내 기프티콘 보관함 보기</a><br><br>
+
+<ul>
+  {% for g in gifticons %}
+    <li>
+      {% if g.remaining_points >= 0 %}
+        <a href="{% url 'visit_rewards:buy_gifticon' g.id %}" 
+           class="gifticon-link"
+           onclick="return confirm('정말 {{ g.name }} 기프티콘을 구매하시겠습니까?\n가격: {{ g.point_cost }}P\n(구매 후 잔여 포인트: {{ g.remaining_points }}P)')">
+          {{ g.name }} - {{ g.point_cost }}P
+        </a>
+      {% else %}
+        <a href="javascript:void(0);" 
+           class="gifticon-link"
+           onclick="alert('잔여 포인트가 부족합니다.')">
+          {{ g.name }} - {{ g.point_cost }}P
+        </a>
+      {% endif %}
+    </li>
+{% endfor %}
+
+</ul>
+
+</body>
+</html>

--- a/visit_rewards/templates/visit_rewards/gifticon_shop.html
+++ b/visit_rewards/templates/visit_rewards/gifticon_shop.html
@@ -38,7 +38,7 @@
         <a href="{% url 'visit_rewards:buy_gifticon' g.id %}" 
            class="gifticon-link"
            onclick="return confirm('정말 {{ g.name }} 기프티콘을 구매하시겠습니까?\n가격: {{ g.point_cost }}P\n(구매 후 잔여 포인트: {{ g.remaining_points }}P)')">
-          {{ g.name }} - {{ g.point_cost }}P
+          {{ g.name }} {{ g.description }}- {{ g.point_cost }}P
         </a>
       {% else %}
         <a href="javascript:void(0);" 

--- a/visit_rewards/templates/visit_rewards/item_shop.html
+++ b/visit_rewards/templates/visit_rewards/item_shop.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>QR 방문 인증</title>
+    <script src="https://unpkg.com/html5-qrcode" type="text/javascript"></script>
+</head>
+<body>
+    <a href="{% url 'visit_rewards:my_rewards' %}">내 리워드 보기</a><br><br>
+    <h2>아이템 샵</h2>
+    <p>보유 포인트: {{ user_points }}점</p>
+
+    <ul>
+        {% for item in items %}
+            <li>
+                {{ item.name }} ({{ item.point_cost }}점)
+                <a href="{% url 'visit_rewards:buy_item' item.id %}">구매</a>
+            </li>
+        {% endfor %}
+    </ul>
+
+
+</body>
+</html>
+    

--- a/visit_rewards/templates/visit_rewards/my_gifticons.html
+++ b/visit_rewards/templates/visit_rewards/my_gifticons.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>내 기프티콘</title>
+    <style>
+      .gifticon-img {
+          cursor: pointer;
+          transition: transform 0.3s ease;
+      }
+      .gifticon-img.enlarged {
+          transform: scale(2); /* 2배 확대 */
+          z-index: 1000;
+          position: relative;
+      }
+    </style>
+</head>
+<body>
+  <a href="{% url 'accounts:mypage' %}">마이페이지</a><br><br>
+  <h3>내 기프티콘</h3>
+  <ul id="gifticon-list">
+      {% for reward in gifticons %}
+          <li id="gift-{{ reward.id }}">
+              {% if reward.gifticon.image %}
+                  <img src="{{ reward.gifticon.image.url }}" 
+                       alt="{{ reward.gifticon.name }}" 
+                       class="gifticon-img"
+                       width="100">
+              {% endif %}
+              사용처 [{{ reward.gifticon.name }}] 유효기간 [~2025.12.31]
+  
+              {% if reward.used %}
+                  (사용 완료)
+              {% else %}
+                  <input type="checkbox" 
+                         class="use-gifticon" 
+                         data-id="{{ reward.id }}">
+                  <label>사용 완료</label>
+              {% endif %}
+          </li>
+      {% empty %}
+          <li>보유한 기프티콘이 없습니다.</li>
+      {% endfor %}
+  </ul>
+  
+  <a href="{% url 'visit_rewards:shop_gifticons' %}">기프티콘 샵으로 돌아가기</a>
+  
+  <script>
+  // 이미지 클릭 시 확대/축소
+  document.addEventListener("DOMContentLoaded", function() {
+      document.querySelectorAll(".gifticon-img").forEach(img => {
+          img.addEventListener("click", function() {
+              this.classList.toggle("enlarged");
+          });
+      });
+  });
+  </script>
+
+  <script>
+  // 체크박스로 기프티콘 사용 처리
+  document.addEventListener("DOMContentLoaded", function() {
+      document.querySelectorAll(".use-gifticon").forEach(function(checkbox) {
+          checkbox.addEventListener("change", function() {
+              const gifticonId = this.dataset.id;
+  
+              if (this.checked) {
+                  if (confirm("정말로 이 기프티콘을 사용하시겠습니까?")) {
+                      fetch("{% url 'visit_rewards:use_gifticon' %}", {
+                          method: "POST",
+                          headers: {
+                              "Content-Type": "application/json",
+                              "X-CSRFToken": "{{ csrf_token }}"
+                          },
+                          body: JSON.stringify({ id: gifticonId })
+                      })
+                      .then(res => {
+                          if (res.ok) {
+                              // 성공 시 화면에서 제거
+                              document.getElementById("gift-" + gifticonId).remove();
+                          } else {
+                              alert("사용 처리에 실패했습니다.");
+                              this.checked = false;
+                          }
+                      });
+                  } else {
+                      this.checked = false; // 취소 시 원상 복구
+                  }
+              }
+          });
+      });
+  });
+  </script>
+</body>
+</html>

--- a/visit_rewards/templates/visit_rewards/my_rewards.html
+++ b/visit_rewards/templates/visit_rewards/my_rewards.html
@@ -8,6 +8,7 @@
 <body>
     <a href="{% url 'accounts:main' %}">홈으로</a><br><br>
     <h2>내 포인트: {{ points }}점</h2>
+   
     <a href="{% url 'visit_rewards:purchase_history' %}">구매 내역</a><br><br>
 
     <h3>내 아이템</h3>

--- a/visit_rewards/templates/visit_rewards/my_rewards.html
+++ b/visit_rewards/templates/visit_rewards/my_rewards.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>QR 방문 인증</title>
+    <script src="https://unpkg.com/html5-qrcode" type="text/javascript"></script>
+</head>
+<body>
+    <a href="{% url 'accounts:main' %}">홈으로</a><br><br>
+    <h2>내 포인트: {{ points }}점</h2>
+
+    <h3>내 아이템</h3>
+    <ul>
+    {% for user_item in items %}
+        <li>{{ user_item.item.name }}</li>
+    {% empty %}
+        <li>보유한 아이템이 없습니다.</li>
+    {% endfor %}
+    </ul>
+
+    <a href="{% url 'visit_rewards:my_gifticons' %}">내 기프티콘</a><br><br>
+
+
+    <a href="{% url 'visit_rewards:shop_items' %}">아이템 샵</a>
+    <a href="{% url 'visit_rewards:shop_gifticons' %}">기프티콘 샵</a>
+
+</body>
+</html>
+    

--- a/visit_rewards/templates/visit_rewards/my_rewards.html
+++ b/visit_rewards/templates/visit_rewards/my_rewards.html
@@ -8,6 +8,7 @@
 <body>
     <a href="{% url 'accounts:main' %}">홈으로</a><br><br>
     <h2>내 포인트: {{ points }}점</h2>
+    <a href="{% url 'visit_rewards:purchase_history' %}">구매 내역</a><br><br>
 
     <h3>내 아이템</h3>
     <ul>

--- a/visit_rewards/templates/visit_rewards/purchase_history.html
+++ b/visit_rewards/templates/visit_rewards/purchase_history.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>구매 내역</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+        h2 {
+            margin-bottom: 20px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 30px;
+        }
+        th, td {
+            padding: 12px;
+            border: 1px solid #ddd;
+            text-align: left;
+        }
+        th {
+            background-color: #f8f8f8;
+        }
+        tr:nth-child(even) {
+            background-color: #f5f5f5;
+        }
+        .back-link {
+            display: inline-block;
+            padding: 8px 12px;
+            background-color: #eee;
+            border-radius: 6px;
+            text-decoration: none;
+            color: #333;
+            transition: background 0.2s;
+        }
+        .back-link:hover {
+            background-color: #ddd;
+        }
+    </style>
+</head>
+<body>
+    <h2>내 기프티콘 구매 내역</h2>
+
+    {% if purchase_history %}
+    <table>
+        <thead>
+            <tr>
+                <th>기프티콘 이름</th>
+                <th>사용 여부</th>
+                <th>포인트 사용량</th>
+                <th>구매 날짜</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for ph in purchase_history %}
+            <tr>
+                <td>{{ ph.gifticon.name }}</td>
+                <td>
+                    {% if ph.used %}
+                        사용 완료
+                    {% else %}
+                        미사용
+                    {% endif %}
+                </td>
+                <td>{{ ph.points_spent }}P</td>
+                <td>{{ ph.purchased_at|date:"Y-m-d H:i" }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+        <p>구매한 기프티콘이 없습니다.</p>
+    {% endif %}
+
+    <a href="{% url 'visit_rewards:shop_gifticons' %}" class="back-link">기프티콘 샵으로 돌아가기</a>
+</body>
+</html>

--- a/visit_rewards/templates/visit_rewards/visit_checking.html
+++ b/visit_rewards/templates/visit_rewards/visit_checking.html
@@ -53,8 +53,10 @@
                 })
                 .then(data => {
                     if (data.status === "ok") {
-                        statusEl.textContent =
-                            `[${data.store_name}] 방문을 환영합니다! (누적 방문 ${data.total_visits}회)`;
+                        statusEl.innerHTML =
+                            `[${data.store_name}] 방문을 환영합니다! (누적 방문 ${data.total_visits}회)<br>` +
+                            `${data.points_earned}포인트가 적립되었습니다! ` +
+                            `<a href="http://127.0.0.1:8000/visit_rewards/rewards/">내 리워드 보기</a>`;
                     } else if (data.status === "already_visited") {
                         statusEl.textContent = "이미 방문한 QR입니다. 내일 다시 시도해주세요.";
                     } else {

--- a/visit_rewards/templates/visit_rewards/visit_history.html
+++ b/visit_rewards/templates/visit_rewards/visit_history.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>나의 방문 내역</title>
+    <style>
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; }
+        tr:hover { background-color: #f9f9f9; }
+        .store-link { color: #007bff; text-decoration: none; font-weight: bold; }
+        .store-link:hover { text-decoration: underline; }
+        .highlight { background-color: #fffae6; padding: 5px; margin-bottom: 10px; display: inline-block; }
+    </style>
+</head>
+<body>
+<h2>나의 방문 내역</h2>
+<a href="{% url 'home:main' %}">홈으로</a>
+<br><br>
+
+{% if most_visited %}
+<div class="highlight">
+    <strong>가장 많이 찾은 가게:</strong>
+    <a href="{% url 'stores:store-detail' most_visited.store__id %}" class="store-link">
+        {{ most_visited.store__name }}
+    </a>
+    (방문 횟수: {{ most_visited.visits_count }}회)
+</div>
+{% endif %}
+
+{% if latest_visit %}
+<div class="highlight">
+    <strong>가장 최근에 찾은 가게:</strong>
+    <a href="{% url 'stores:store-detail' latest_visit.store.id %}" class="store-link">
+        {{ latest_visit.store.name }}
+    </a>
+    (방문 시간: {{ latest_visit.visit_time|date:"Y-m-d H:i" }})
+</div>
+{% endif %}
+
+{% if visits %}
+<table>
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>가게 이름</th>
+            <th>테스트 여부</th>
+            <th>방문 시간</th>
+            <th>획득 포인트</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for visit in visits %}
+        <tr>
+            <td>{{ forloop.counter }}</td>
+            <td>
+                <a href="{% url 'stores:store-detail' visit.store.id %}" class="store-link">
+                    {{ visit.store.name }}
+                </a>
+            </td>
+            <td>{% if visit.test %}테스트{% else %}실제{% endif %}</td>
+            <td>{{ visit.visit_time|date:"Y-m-d H:i" }}</td>
+            <td>
+                {% with visit.reward_set.first as r %}
+                    {% if r %}{{ r.amount }}P{% else %}-{% endif %}
+                {% endwith %}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>아직 방문한 가게가 없습니다.</p>
+{% endif %}
+</body>
+</html>

--- a/visit_rewards/urls.py
+++ b/visit_rewards/urls.py
@@ -20,4 +20,7 @@ urlpatterns = [
     path('shop/gifticons/buy/<int:gifticon_id>/', views.buy_gifticon, name='buy_gifticon'),  # 기프티콘 구매
     path('gifticons/my/', views.my_gifticons, name='my_gifticons'),              # 보유 기프티콘 확인
     path('gifticons/use/', views.use_gifticon, name='use_gifticon'),
+    
+    # 구매 내역
+    path('gifticons/purchase-history/', views.purchase_history, name='purchase_history'),
 ]

--- a/visit_rewards/urls.py
+++ b/visit_rewards/urls.py
@@ -4,7 +4,20 @@ from . import views
 app_name = "visit_rewards"
 
 urlpatterns = [
-  
-    path('visit_check/<int:store_id>/', views.visit_check, name='visit_check'),# QR 인증 화면
-    path('visit/', views.visit_store, name='visit_store'),  # QR 스캔 후 API
+    # 방문 관련
+    path('visit_check/<int:store_id>/', views.visit_check, name='visit_check'),  # QR 인증 화면
+    path('visit/', views.visit_store, name='visit_store'),                        # QR 스캔 후 API
+
+    # 내 보유 포인트/아이템/기프티콘
+    path('rewards/', views.my_rewards, name='my_rewards'),
+
+    # 꾸미기 아이템 관련
+    path('shop/items/', views.shop_items, name='shop_items'),                     # 아이템 샵
+    path('shop/items/buy/<int:item_id>/', views.buy_item, name='buy_item'),      # 아이템 구매
+
+    # 기프티콘 관련
+    path('shop/gifticons/', views.shop_gifticons, name='shop_gifticons'),        # 기프티콘 샵
+    path('shop/gifticons/buy/<int:gifticon_id>/', views.buy_gifticon, name='buy_gifticon'),  # 기프티콘 구매
+    path('gifticons/my/', views.my_gifticons, name='my_gifticons'),              # 보유 기프티콘 확인
+    path('gifticons/use/', views.use_gifticon, name='use_gifticon'),
 ]

--- a/visit_rewards/urls.py
+++ b/visit_rewards/urls.py
@@ -23,4 +23,6 @@ urlpatterns = [
     
     # 구매 내역
     path('gifticons/purchase-history/', views.purchase_history, name='purchase_history'),
+    # 방문 내역
+    path('visit_history/', views.visit_history, name='visit_history'),
 ]

--- a/visit_rewards/views.py
+++ b/visit_rewards/views.py
@@ -52,25 +52,23 @@ def visit_store(request):
 
     store = get_object_or_404(Store, qr_token=token)
 
-    if not is_test and Visit.objects.filter(store=store, user=request.user).exists():
-        return JsonResponse({"status": "already_visited"})
-
-        # 방문 인증 생성
+    # 방문 인증 생성
     visit = Visit.objects.create(store=store, test=is_test, user=request.user)
 
     # 포인트 적립 (예: 방문 인증 1000포인트)
     points_earned = 1000
     Reward.objects.create(
-    user=request.user,
-    reward_type='visit',
-    amount=points_earned,
-    related_visit=visit
-)
-    
+        user=request.user,
+        reward_type='visit',
+        amount=points_earned,
+        related_visit=visit
+    )
+
     request.user.points += points_earned
     request.user.save()
 
-    total_visits = Visit.objects.filter(store=store).count()
+    # 로그인 사용자 기준 누적 방문 횟수
+    total_visits = Visit.objects.filter(store=store, user=request.user).count()
 
     return JsonResponse({
         "status": "ok",

--- a/visit_rewards/views.py
+++ b/visit_rewards/views.py
@@ -1,9 +1,14 @@
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, render,redirect
 from django.http import JsonResponse, HttpResponse
 from .models import Store, Visit
 import uuid, base64, qrcode
 from io import BytesIO
 from django.contrib.auth.decorators import login_required
+from django.contrib import messages
+from .models import *
+from django.db.models import Sum
+from django.views.decorators.http import require_POST
+import json
 
 # 방문 인증 페이지 + QR 생성
 def visit_check(request, store_id):
@@ -50,12 +55,196 @@ def visit_store(request):
     if not is_test and Visit.objects.filter(store=store, user=request.user).exists():
         return JsonResponse({"status": "already_visited"})
 
-    Visit.objects.create(store=store, test=is_test, user=request.user)
+        # 방문 인증 생성
+    visit = Visit.objects.create(store=store, test=is_test, user=request.user)
+
+    # 포인트 적립 (예: 방문 인증 1000포인트)
+    points_earned = 1000
+    Reward.objects.create(
+    user=request.user,
+    reward_type='visit',
+    amount=points_earned,
+    related_visit=visit
+)
+    
+    request.user.points += points_earned
+    request.user.save()
 
     total_visits = Visit.objects.filter(store=store).count()
 
     return JsonResponse({
         "status": "ok",
         "store_name": store.name,
-        "total_visits": total_visits
+        "total_visits": total_visits,
+        "points_earned": points_earned
     })
+
+
+#이 위로 방문인증 관련
+#-----------------------------------------------------------------------
+#이 밑으로 리워드 관련
+
+@login_required
+def my_rewards(request):
+    """유저가 가진 포인트와 아이템 확인"""
+    total_points = Reward.objects.filter(
+        user=request.user,
+        used=False,
+        amount__gt=0
+    ).aggregate(total=Sum('amount'))['total'] or 0
+
+    # 사용되지 않은 꾸미기 아이템
+    items_qs = Reward.objects.filter(
+        user=request.user,
+        item__isnull=False,
+        used=False
+    ).select_related('item')
+    items = list({r.item for r in items_qs})
+
+    # 보유 기프티콘
+    gifticons_qs = Reward.objects.filter(
+        user=request.user,
+        gifticon__isnull=False,
+        used=False
+    ).select_related('gifticon')
+    gifticons = list({r.gifticon for r in gifticons_qs})
+
+    return render(request, 'visit_rewards/my_rewards.html', {
+        'points': total_points,
+        'items': items,
+        'gifticons': gifticons,
+    })
+
+
+@login_required
+def shop_items(request):
+    """구매 가능한 꾸미기 아이템 목록"""
+    items = Item.objects.all()
+    user_points = Reward.objects.filter(user=request.user, amount__gt=0, used=False).aggregate(total=Sum('amount'))['total'] or 0
+    return render(request, 'visit_rewards/item_shop.html', {'items': items, 'user_points': user_points})
+
+
+@login_required
+def buy_item(request, item_id):
+    """포인트로 꾸미기 아이템 구매"""
+    item = get_object_or_404(Item, pk=item_id)
+    user_points = Reward.objects.filter(user=request.user, amount__gt=0, used=False).aggregate(total=Sum('amount'))['total'] or 0
+
+    if user_points < item.point_cost:
+        messages.error(request, f"포인트가 부족합니다. 현재 {user_points}점, 아이템 비용 {item.point_cost}점")
+        return redirect('visit_rewards:shop_items')
+
+    # 포인트 차감
+    remaining_cost = item.point_cost
+    rewards = Reward.objects.filter(user=request.user, amount__gt=0, used=False).order_by('created_at')
+    for r in rewards:
+        if r.amount >= remaining_cost:
+            r.amount -= remaining_cost
+            if r.amount == 0:
+                r.used = True
+            r.save()
+            break
+        else:
+            remaining_cost -= r.amount
+            r.amount = 0
+            r.used = True
+            r.save()
+
+    # 구매 기록 생성
+    PurchaseHistory.objects.create(user=request.user, item=item, points_spent=item.point_cost)
+
+    # 아이템 지급
+    Reward.objects.create(user=request.user, item=item, amount=0)
+
+    messages.success(request, f"{item.name} 아이템을 구매했습니다!")
+    return redirect('visit_rewards:my_rewards')
+
+
+@login_required
+def shop_gifticons(request):
+    """구매 가능한 기프티콘 목록"""
+    # 모든 기프티콘 가져오기
+    gifticons = Gifticon.objects.all()
+
+    # 유저 현재 포인트 계산
+    user_points = Reward.objects.filter(
+        user=request.user,
+        amount__gt=0,
+        used=False
+    ).aggregate(total=Sum('amount'))['total'] or 0
+
+    # 각 기프티콘별 구매 후 잔여 포인트 계산
+    for g in gifticons:
+        g.remaining_points = user_points - g.point_cost
+
+    return render(request, 'visit_rewards/gifticon_shop.html', {
+        'gifticons': gifticons,
+        'user_points': user_points,
+    })
+
+@login_required
+def buy_gifticon(request, gifticon_id):
+    """포인트로 기프티콘 구매"""
+    gifticon = get_object_or_404(Gifticon, pk=gifticon_id)
+    user_points = Reward.objects.filter(user=request.user, amount__gt=0, used=False).aggregate(total=Sum('amount'))['total'] or 0
+
+    if user_points < gifticon.point_cost:
+        messages.error(request, f"포인트가 부족합니다. 현재 {user_points}점, 기프티콘 비용 {gifticon.point_cost}점")
+        return redirect('visit_rewards:shop_gifticons')
+
+    # 포인트 차감
+    remaining_cost = gifticon.point_cost
+    rewards = Reward.objects.filter(user=request.user, amount__gt=0, used=False).order_by('created_at')
+    for r in rewards:
+        if r.amount >= remaining_cost:
+            r.amount -= remaining_cost
+            if r.amount == 0:
+                r.used = True
+            r.save()
+            break
+        else:
+            remaining_cost -= r.amount
+            r.amount = 0
+            r.used = True
+            r.save()
+
+    # 구매 기록 생성
+    PurchaseHistory.objects.create(user=request.user, gifticon=gifticon, points_spent=gifticon.point_cost)
+
+    # 기프티콘 지급
+    Reward.objects.create(user=request.user, gifticon=gifticon, amount=0)
+
+    messages.success(request, f"{gifticon.name} 기프티콘을 구매했습니다!")
+    return redirect('visit_rewards:my_rewards')
+
+
+@login_required
+def my_gifticons(request):
+    """유저가 보유한 기프티콘 확인"""
+    gifticons = Reward.objects.filter(
+        user=request.user,
+        gifticon__isnull=False,
+        used=False
+    ).select_related('gifticon')
+
+    return render(request, 'visit_rewards/my_gifticons.html', {'gifticons': gifticons})
+
+@login_required
+@require_POST
+def use_gifticon(request):
+    """체크박스로 기프티콘 사용 처리"""
+    try:
+        data = json.loads(request.body)
+        reward_id = data.get("id")
+    except (json.JSONDecodeError, KeyError):
+        return JsonResponse({"success": False, "error": "잘못된 요청"}, status=400)
+
+    reward = get_object_or_404(Reward, id=reward_id, user=request.user, gifticon__isnull=False)
+
+    if reward.used:
+        return JsonResponse({"success": False, "error": "이미 사용된 기프티콘"}, status=400)
+
+    reward.used = True
+    reward.save()
+
+    return JsonResponse({"success": True})

--- a/visit_rewards/views.py
+++ b/visit_rewards/views.py
@@ -248,3 +248,18 @@ def use_gifticon(request):
     reward.save()
 
     return JsonResponse({"success": True})
+
+@login_required
+def purchase_history(request):
+    """
+    현재 유저의 기프티콘 구매 내역
+    """
+    history = PurchaseHistory.objects.filter(user=request.user).select_related('gifticon').order_by('-purchased_at')
+    
+    # 각 구매 내역마다 사용 여부 표시
+    for ph in history:
+        ph.used = Reward.objects.filter(user=request.user, gifticon=ph.gifticon, used=True).exists()
+    
+    return render(request, 'visit_rewards/purchase_history.html', {
+        'purchase_history': history
+    })


### PR DESCRIPTION
## 📌 개요
- 사용자 선호 지역 및 음식 종류 설정 추가
- 관심 가게(찜) 등록 및 목록 확인

## ✨ 작업 내용
- 마이페이지>관심 설정: 사용자 선호 지역 및 음식 종류 설정 및 수정
- 가게 상세페이지>찜등록/해제 기능 추가
- 마이페이지>찜한 가게: 찜 등록된 가게 목록 확인 및 간편 찜 해제 기능 추가

## ✅ 확인 방법
- 마이페이지>관심 설정>수정 눌러서 지역 및 음식 잘 등록, 마이페이지에서 등록 내용 잘 반영되는지 확인
- 가게 상세 페이지에서 찜 등록/해제가 정상적으로 되는지 확인
- 마이페이지>찜한 가게 에서 찜 등록한 가게 목록이 잘 보이는지 확인
- 마이페이지>찜한 가게 에서 찜 등록한 가게를 간편 이동 및 찜 해제가 가능한지 확인

## 🔗 관련 이슈
- closes #22 
- 가게 DB 있어야 방문인증 테스트 가능
>임시로 방문인증 페이지에서 해당 가게의 QR 이미지를 띄워두었으니 핸드폰으로 캡쳐 후 컴퓨터 카메라에 스캔해보세요