### PR TITLE
[fix,refactor] 방문인증 기반 리뷰 작성 권한 제어, 포인트 관리

### DIFF
--- a/stores/templates/stores/public-store-list.html
+++ b/stores/templates/stores/public-store-list.html
@@ -48,9 +48,6 @@
             </a>
             <br/>
 
-            <!-- 방문 수 -->
-            방문 수: {{ store.visit_count }}
-            <br/>
 
             주소: {{ store.address }}<br/>
             카테고리:

--- a/stores/templates/stores/store-detail.html
+++ b/stores/templates/stores/store-detail.html
@@ -63,7 +63,17 @@
         {% endif %}
     <br/>
 
-    <a href="{% url 'reviews:review-create' store.id %}">리뷰 작성</a>
+    <a href="{% url 'reviews:review-create' store.id %}" class="btn">리뷰 작성</a>
+
+    {% if messages %}
+    <script>
+    {% for message in messages %}
+        alert('{{ message }}');
+    {% endfor %}
+    </script>
+    {% endif %}
+    
+
     <hr/>
     <br/>
 

--- a/visit_rewards/models.py
+++ b/visit_rewards/models.py
@@ -74,6 +74,7 @@ class Reward(models.Model):
     store = models.ForeignKey(Store, on_delete=models.CASCADE, null=True, blank=True)
     reward_type = models.CharField(max_length=20, choices=REWARD_TYPE_CHOICES, default='point')
     related_visit = models.ForeignKey(Visit, null=True, blank=True, on_delete=models.SET_NULL)
+    related_review = models.ForeignKey('reviews.Review', null=True, blank=True, on_delete=models.SET_NULL)  # 추가
     amount = models.PositiveIntegerField(default=0)  # 포인트
     item = models.ForeignKey(Item, on_delete=models.SET_NULL, null=True, blank=True)
     gifticon = models.ForeignKey(Gifticon, on_delete=models.SET_NULL, null=True, blank=True)
@@ -87,6 +88,7 @@ class Reward(models.Model):
         if self.gifticon:
             return f"{self.user.username} - {self.gifticon.name}"
         return f"{self.user.username} - {self.reward_type} - {self.amount}"
+
     
 class PurchaseHistory(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)


### PR DESCRIPTION
## 📌 개요
- 방문인증 기반 리뷰 관련 제어, 포인트 관리

## ✨ 작업 내용
- QR 방문인증 시간 기준 24시간 이내에만 리뷰 작성 허용(24시간 내 기록 없으면 작성 불가)
- 24시간 내 기록 있어도 중복 작성 차단(방문 횟수만큼만 리뷰 작성 가능: 방문 1회 당 리뷰 1건 제한)
- Reward 모델 수정
- 리뷰 작성 시 500p 자동 적립

## ✅ 확인 방법
- 24시간 이내에 QR 인증 기록이 없는 가게의 리뷰 작성이 차단되는지 확인
- 24시간 이내에 인증 기록이 있는 가게의 리뷰 작성이 가능한지 확인
- 24시간 이내의 방문 횟수 만큼만 리뷰 작성이 가능한지 확인
- 리뷰 작성 시 500p 자동 적립되는지 확인

## 🔗 관련 이슈
- closes #29 
- 가게 DB 있어야 방문인증 테스트 가능
>임시로 방문인증 페이지에서 해당 가게의 QR 이미지를 띄워두었으니 핸드폰으로 캡쳐 후 컴퓨터 카메라에 스캔해보세요